### PR TITLE
title => panelTitle?

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Attributes:
 * noHeader - Boolean, Default: false
 * open - Boolean, Default: true - notifies
 * showExpandBtn - Boolean, Default: false
-* title - String, Default: Panel title
+* panelTitle - String, Default: Panel title
 
 All attributes of the element are not required.
 

--- a/README.md
+++ b/README.md
@@ -6,23 +6,23 @@ A simple panel with header to display a collapsible content.
 
 ## Usage
 ```html
-<etools-content-panel title="Panel title" show-expand-btn>
+<etools-content-panel panel-title="Panel title" show-expand-btn>
   <div>Your content goes here...</div>
 </etools-content-panel>
 
-<etools-content-panel title="Panel title" no-header elevation="2">
+<etools-content-panel panel-title="Panel title" no-header elevation="2">
   <div>Only content, no header...</div>
 </etools-content-panel>
 
-<etools-content-panel title="Panel title" elevation="3" is-disabled="true" show-expand-btn>
+<etools-content-panel panel-title="Panel title" elevation="3" is-disabled="true" show-expand-btn>
   <div>Disabled state...</div>
 </etools-content-panel>
 
-<etools-content-panel title="Panel title" elevation="4">
+<etools-content-panel panel-title="Panel title" elevation="4">
   <div>No content expand or collapse button</div>
 </etools-content-panel>
 
-<etools-content-panel title="Panel title" title-style="align-center" elevation="5">
+<etools-content-panel panel-title="Panel title" title-style="align-center" elevation="5">
   <div>Panel elevation increased to maximum value</div>
 </etools-content-panel>
 ```

--- a/demo/index.html
+++ b/demo/index.html
@@ -27,23 +27,23 @@
 
       <demo-snippet>
         <template>
-          <etools-content-panel title="Panel title" show-expand-btn>
+          <etools-content-panel panel-title="Panel title" show-expand-btn>
             <div>Your content goes here...</div>
           </etools-content-panel>
 
-          <etools-content-panel title="Panel title" no-header elevation="2">
+          <etools-content-panel panel-title="Panel title" no-header elevation="2">
             <div>Only content, no header...</div>
           </etools-content-panel>
 
-          <etools-content-panel title="Panel title" elevation="3" is-disabled="true" show-expand-btn>
+          <etools-content-panel panel-title="Panel title" elevation="3" is-disabled="true" show-expand-btn>
             <div>Disabled state...</div>
           </etools-content-panel>
 
-          <etools-content-panel title="Panel title" elevation="4">
+          <etools-content-panel panel-title="Panel title" elevation="4">
             <div>No content expand or collapse button</div>
           </etools-content-panel>
 
-          <etools-content-panel title="Panel title" title-style="align-center" elevation="5">
+          <etools-content-panel panel-title="Panel title" title-style="align-center" elevation="5">
             <div>Panel elevation increased to maximum value</div>
           </etools-content-panel>
         </template>

--- a/etools-content-panel.html
+++ b/etools-content-panel.html
@@ -86,7 +86,7 @@ Custom property | Description | Default
                            icon$="[[_getExpandBtnIcon(open)]]"
                            hidden$="[[!showExpandBtn]]"
                            disabled$="[[isDisabled]]"></paper-icon-button>
-        <div class="title">[[title]]</div>
+        <div class="title">[[panelTitle]]</div>
       </paper-toolbar>
       <iron-collapse opened="{{open}}">
         <div id="content-wrapper">
@@ -105,7 +105,7 @@ Custom property | Description | Default
         is: 'etools-content-panel',
 
         properties: {
-          title: {
+          panelTitle: {
             type: String,
             value: 'Panel title'
           },


### PR DESCRIPTION
The `title` attr triggers native browser tooltips. How about replacing it with `pageTitle` and bumping the major (breaking change) version of the package?